### PR TITLE
Ensure error events emitted by the ldap client are caught, and cause the promise to reject.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,9 @@ export default class SimpleLDAPSearch {
       }
 
       self.isBinding = true;
+      this.client.once('error', reject);
       return this.client.bind(dn, password, (err, res) => {
+        this.client.removeAllListeners('error');
         if (err) return reject(err);
 
         self.isBinding = false;
@@ -80,7 +82,9 @@ export default class SimpleLDAPSearch {
     await self.bindDN();
 
     return new Promise((resolve, reject) => {
+      this.client.once('error', reject);
       self.client.search(self.config.base, opts, (err, res) => {
+        this.client.removeAllListeners('error');
         if (err) {
           return reject(`search failed ${err.message}`);
         }


### PR DESCRIPTION
There is some frustrating behavior in ldapjs where some errors are emitted from the client object rather than calling the error callback of any given method. Currently simple-ldap-search doesn't catch those errors, so they don't cause the promise to reject, and worse they kill the active node process. There is no really way to catch them externally either (they arent synchronous, nor are they part of the current promise chain).
The scenario is really easy to reproduce, just try to call search against a url which doesnt respond - when the HTTP request for bind times out the node process will get killed by an uncaught exception.