### PR TITLE
starting TLS on LDAP connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,13 @@ Returns
 ### `ldap.destroy()`
 
 Destroys the connection to the LDAP server. Use when all done with LDAP client.
+
+### `ldap.starttls(opts)`
+Parameters
+
+- `opts`: Object of TLS Options documented on [LDAPjs's Client API page](http://ldapjs.org/client.html#starttls)
+```
+const opts = {
+  ca: [fs.readFileSync('mycacert.pem')]
+};
+```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const users = await ldap.search(filter, attributes);
 
 ### `ldap.search(filter, attributes)`
 
-Parameters
+#### Parameters
 
 - `filter`: filters results.
 - `attributes`: a list of attributes to return
@@ -66,7 +66,8 @@ Returns
 Destroys the connection to the LDAP server. Use when all done with LDAP client.
 
 ### `ldap.starttls(opts)`
-Parameters
+
+#### Parameters
 
 - `opts`: Object of TLS Options documented on [LDAPjs's Client API page](http://ldapjs.org/client.html#starttls)
 ```

--- a/index.js
+++ b/index.js
@@ -108,4 +108,28 @@ export default class SimpleLDAPSearch {
       });
     });
   }
+
+  /**
+   * Secures the LDAP opject by using the STARTTLS verb
+   * @param {Object} opts - STARTTLS options
+   * @returns {Promise|Error} - Resolves the promise or returns the error from ldapjs
+   */
+  async starttls(opts) {
+    const self = this;
+    
+    return new Promise((resolve, reject) => {
+      // add listener to ldapjs client for error
+      addListenerIfNotAdded(this.client, 'error', reject);
+
+      // starts TLS on the LDAP
+      self.client.starttls(opts, undefined, (err, res) => {
+        // if we receive an error back
+        if (err) {
+          return reject(new Error(`STARTTLS failed: ${err.message}`));
+        }
+        // since ldapjs doesn't return timing, we just resolve if we have no error
+        resolve(res);
+      });
+    });
+  }
 }

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ export default class SimpleLDAPSearch {
   }
 
   /**
-   * Secures the LDAP opject by using the STARTTLS verb
+   * Secures the LDAP object by using the STARTTLS verb
    * @param {Object} opts - STARTTLS options
    * @returns {Promise|Error} - Resolves the promise or returns the error from ldapjs
    */

--- a/lib/arrayIncludesFunction.js
+++ b/lib/arrayIncludesFunction.js
@@ -5,7 +5,7 @@
  */
 export default function arrayIncludesFunction(arr, fn) {
   if (typeof fn !== 'function') {
-    throw TypeError(`Function '${fn} is not a function`);
+    throw new TypeError(`Function '${fn}' is not a function`);
   }
   return !!arr.find((el) => el.toString() === fn.toString());
 }

--- a/lib/arrayIncludesFunction.test.js
+++ b/lib/arrayIncludesFunction.test.js
@@ -35,4 +35,8 @@ describe('arrayIncludesFunction', () => {
 
     expect(arrayIncludesFunction(arr, print2)).toBe(false);
   });
+
+  it('throws TypeError if fn is not a function', () => {
+    expect(() => arrayIncludesFunction([1, 2, 3], 5)).toThrow(TypeError);
+  });
 });


### PR DESCRIPTION
This pull adds the code to secure the LDAP connection using STARTTLS by utilizing [LDAPjs's starttls function](http://ldapjs.org/client.html#starttls) and the documentation on how to utilize it in the README