### PR TITLE
added timeLimit to search query.

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,12 +78,13 @@ export default class SimpleLDAPSearch {
    * searches ldap. Will autobind if
    * this.config.dn and this.config.password are set.
    */
-  async search(filter = '(objectclass=*)', attributes) {
+  async search(filter = '(objectclass=*)', attributes, timeLimit=10) {
     const self = this;
     const opts = {
       scope: 'sub',
       filter,
       attributes,
+      timeLimit,
     };
     const results = [];
 


### PR DESCRIPTION
added timeLimit with a default that matches ldapjs to not break backwards compatibility

Using this package we were seeing timeLimit errors and I didnt find a good way to pass a timelimit from simple-ldap-search to the ldapjs module.

We take in the timeLimit into the search function as a default paramter that matches the timeout of ldapjs: http://ldapjs.org/client.html#search

We then add timeLimit back to the opts variable with filter and attributes parameters.